### PR TITLE
remove inner functions / add colors to phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "scripts": {
         "phpcs": "phpcs",
-        "phpunit": "phpunit",
+        "phpunit": "phpunit --colors=always",
         "test": "phpunit tests"
     },
     "autoload": {

--- a/src/trees.php
+++ b/src/trees.php
@@ -130,9 +130,7 @@ function map($func, $tree)
     $children = $tree['children'] ?? [];
 
     if (isDirectory($tree)) {
-        $updatedChildren = array_map(function ($node) use ($func) {
-            return map($func, $node);
-        }, $children);
+        $updatedChildren = array_map(fn($node) => map($func, $node), $children);
         return array_merge($updatedNode, ['children' => $updatedChildren]);
     }
 
@@ -157,9 +155,7 @@ function reduce($func, $tree, $accumulator)
 
     return array_reduce(
         $children,
-        function ($acc, $node) use ($func) {
-            return reduce($func, $node, $acc);
-        },
+        fn($acc, $node) => reduce($func, $node, $acc),
         $newAcc
     );
 }
@@ -179,15 +175,8 @@ function filter($func, $tree)
     $children = $tree['children'] ?? null;
 
     if (isDirectory($tree)) {
-        $updatedChildren = array_map(function ($node) use ($func) {
-            return filter($func, $node);
-        }, $children);
-
-        $filteredChildren = array_filter($updatedChildren, function ($node) {
-            if ($node != null) {
-                return $node;
-            }
-        });
+        $updatedChildren = array_map(fn($node) => filter($func, $node), $children);
+        $filteredChildren = array_filter($updatedChildren);
         return array_merge($tree, ['children' => array_values($filteredChildren)]);
     }
 

--- a/src/trees.php
+++ b/src/trees.php
@@ -126,22 +126,17 @@ function array_flatten($tree, $depth = 0)
  */
 function map($func, $tree)
 {
-    $map = function ($f, $node) use (&$map) {
-        $updatedNode = $f($node);
+    $updatedNode = $func($tree);
+    $children = $tree['children'] ?? [];
 
-        $children = $node['children'] ?? [];
+    if (isDirectory($tree)) {
+        $updatedChildren = array_map(function ($node) use ($func) {
+            return map($func, $node);
+        }, $children);
+        return array_merge($updatedNode, ['children' => $updatedChildren]);
+    }
 
-        if (isDirectory($node)) {
-            $updatedChildren = array_map(function ($n) use (&$f, &$map) {
-                return $map($f, $n);
-            }, $children);
-            return array_merge($updatedNode, ['children' => $updatedChildren]);
-        }
-
-        return $updatedNode;
-    };
-
-    return $map($func, $tree);
+    return $updatedNode;
 }
 
 /**
@@ -153,24 +148,20 @@ function map($func, $tree)
  */
 function reduce($func, $tree, $accumulator)
 {
-    $reduce = function ($f, $node, $acc) use (&$reduce) {
-        $children = $node['children'] ?? [];
-        $newAcc = $f($acc, $node);
+    $children = $tree['children'] ?? [];
+    $newAcc = $func($accumulator, $tree);
 
-        if (isFile($node)) {
-            return $newAcc;
-        }
+    if (isFile($tree)) {
+        return $newAcc;
+    }
 
-        return array_reduce(
-            $children,
-            function ($iAcc, $n) use (&$reduce, &$f) {
-                return $reduce($f, $n, $iAcc);
-            },
-            $newAcc
-        );
-    };
-
-    return $reduce($func, $tree, $accumulator);
+    return array_reduce(
+        $children,
+        function ($acc, $node) use ($func) {
+            return reduce($func, $node, $acc);
+        },
+        $newAcc
+    );
 }
 
 /**
@@ -181,28 +172,24 @@ function reduce($func, $tree, $accumulator)
  */
 function filter($func, $tree)
 {
-    $filter = function ($f, $node) use (&$filter) {
-        if (!$f($node)) {
-            return null;
-        }
+    if (!$func($tree)) {
+        return null;
+    }
 
-        $children = $node['children'] ?? null;
+    $children = $tree['children'] ?? null;
 
-        if (isDirectory($node)) {
-            $updatedChildren = array_map(function ($n) use (&$f, &$filter) {
-                return $filter($f, $n);
-            }, $children);
+    if (isDirectory($tree)) {
+        $updatedChildren = array_map(function ($node) use ($func) {
+            return filter($func, $node);
+        }, $children);
 
-            $filteredChildren = array_filter($updatedChildren, function ($n) {
-                if ($n != null) {
-                    return $n;
-                }
-            });
-            return array_merge($node, ['children' => array_values($filteredChildren)]);
-        }
+        $filteredChildren = array_filter($updatedChildren, function ($node) {
+            if ($node != null) {
+                return $node;
+            }
+        });
+        return array_merge($tree, ['children' => array_values($filteredChildren)]);
+    }
 
-        return $node;
-    };
-
-    return $filter($func, $tree);
+    return $tree;
 }

--- a/tests/TreesTest.php
+++ b/tests/TreesTest.php
@@ -167,9 +167,7 @@ class TreesTest extends TestCase
             mkfile('hOsts'),
         ]);
 
-        $actual = reduce(function ($acc) {
-            return $acc + 1;
-        }, $tree, 0);
+        $actual = reduce(fn($acc) => $acc + 1, $tree, 0);
         $this->assertEquals(6, $actual);
 
         $actual2 = reduce(function ($acc, $n) {
@@ -177,9 +175,7 @@ class TreesTest extends TestCase
         }, $tree, 0);
         $this->assertEquals(2, $actual2);
 
-        $actual3 = reduce(function ($acc, $n) {
-            return $n['type'] == 'directory' ? $acc + 1 : $acc;
-        }, $tree, 0);
+        $actual3 = reduce(fn($acc, $n) => $n['type'] == 'directory' ? $acc + 1 : $acc, $tree, 0);
         $this->assertEquals(4, $actual3);
     }
 
@@ -197,9 +193,7 @@ class TreesTest extends TestCase
               mkfile('hosts'),
         ]);
 
-        $actual = filter(function ($n) {
-            return $n['type'] == 'directory';
-        }, $tree);
+        $actual = filter(fn($n) => $n['type'] == 'directory', $tree);
 
         $expected = [
             'children' => [
@@ -252,10 +246,7 @@ class TreesTest extends TestCase
 
         $names = ['/', 'hosts'];
 
-        $actual = filter(function ($n) use ($names) {
-            return in_array($n['name'], $names);
-        }, $tree);
-
+        $actual = filter(fn($n) => in_array($n['name'], $names), $tree);
         $expected = [
             'name' => '/',
             'children' => [[


### PR DESCRIPTION
Избавился от внутренних функций в `map`, `filter` и `reduce`. Добавил `colors=always` к запуску `phpunit`.